### PR TITLE
Opt-out option for HTML encode

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ formatter.preFormat(micropubDocument)
 * **filesStyle** – the filename style of uploaded files, in an extended form of the Jekyll [permalink style](https://jekyllrb.com/docs/permalinks/). Should not include file extension, but should include `:filesslug`. Defaults to: `media/:year-:month-:slug/:filesslug`
 * **layoutName** – the name of a layout that overrides the default `micropubpost` one, or `false` to remove the layout completely from the front matter
 * **permalinkStyle** – a Jekyll [permalink style](https://jekyllrb.com/docs/permalinks/). Defaults to Jekyll's default: `date`
+* **encodeHTML** – if set to `false` then HTML-encoding will not happen for the content value. Defaults to `true`
 
 `layoutName`, `filenameStyle`, `filesStyle` and `permalinkStyle` can all be set directly or through a callback that's given some data and that callback might either return a value directly or return a `Promise` that eventually resolves to the value.
 

--- a/index.js
+++ b/index.js
@@ -183,11 +183,8 @@ Formatter.prototype._formatContent = function (data) {
           });
         }) : content.html;
       }
-      if (!this.encodeHTML) {
-        return content.value || '';
-      }
 
-      return escapeHtml(content.value || '');
+      return this.encodeHTML ? escapeHtml(content.value || '') : content.value || '';
     }))
       .then(result => result.filter(value => !!value).join('\n') + '\n');
   }

--- a/index.js
+++ b/index.js
@@ -98,6 +98,7 @@ const Formatter = function (options) {
   this.permalinkStyle = options.permalinkStyle;
   this.deriveCategory = options.deriveCategory === undefined ? true : options.deriveCategory;
   this.layoutName = options.layoutName;
+  this.encodeHTML = options.encodeHTML === undefined ? true : options.encodeHTML;
 
   if (typeof this.filenameStyle !== 'function' && !this.filenameStyle.includes(':')) {
     throw new Error('Invalid filenameStyle, must include a placeholder');
@@ -181,6 +182,9 @@ Formatter.prototype._formatContent = function (data) {
             resolve(err ? content.html : markdown);
           });
         }) : content.html;
+      }
+      if (!this.encodeHTML) {
+        return content.value || '';
       }
 
       return escapeHtml(content.value || '');

--- a/test/formatter.spec.js
+++ b/test/formatter.spec.js
@@ -269,5 +269,21 @@ describe('Formatter', function () {
         '&lt;p&gt;Abc&lt;/p&gt;&lt;p&gt;123&lt;/p&gt;&lt;ul&gt;&lt;li&gt;Foo&lt;/li&gt;&lt;li&gt;Bar&lt;/li&gt;&lt;/ul&gt;\n'
       );
     });
+
+    it('should not encode value to HTML if opted out', function () {
+      baseMicroformatData.properties.content = [{ value: '> Hello World' }];
+
+      formatter = new Formatter({ encodeHTML: false });
+
+      return formatter.format(baseMicroformatData).should.eventually.equal(
+        '---\n' +
+        'layout: micropubpost\n' +
+        'date: \'2015-06-30T14:34:01.000Z\'\n' +
+        'title: awesomeness is awesome\n' +
+        'slug: awesomeness-is-awesome\n' +
+        '---\n' +
+        '> Hello World\n'
+      );
+    });
   });
 });


### PR DESCRIPTION
Added an option that allows users to out-out of encoding HTML of content value. Reason behind this update and the approach is captured as part of the conversation on issue #8. 

A new option `encodeHTML` is added, which when set to `false`, disables HTML encoding of the content value.